### PR TITLE
Do not require python3 in the shebang

### DIFF
--- a/ovh-dynhost.py
+++ b/ovh-dynhost.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 """
 This scripts updates the DynHost configured on your domain registered on ovh.
 Before running this script you need to create a DynHost using the Manager Web


### PR DESCRIPTION
Hey!

Thanks for the script, it seems to work just fine.
I noticed this script also worked just fine with python 2. Since I (kinda mistakenly) installed the dependencies for python 2 only on my raspberry pi, I figured I'd modify the script to work with python2.

Not a lot of work, as you can see. I didn't test every case, but the default scenario (with a config file) works just fine.

Cheers!