### PR TITLE
Remove Same IP error Code

### DIFF
--- a/ovh_dynhost/ovh_dynhost.py
+++ b/ovh_dynhost/ovh_dynhost.py
@@ -54,7 +54,6 @@ DEFAULT_CONF_PATH = os.path.join(os.getenv("HOME"), ".ovh-dynhost.conf")
 OVH_API_ENDPOINT = "https://www.ovh.com/nic/update"
 
 # EXIT CODES
-SAME_IP_ERROR = 75
 GENERAL_ERROR = 1
 
 
@@ -172,7 +171,7 @@ def main():
         sys.exit(0)
     elif "nochg" in response:
         LOGGER.debug("Matching same IP.  Not changed")
-        sys.exit(SAME_IP_ERROR)
+        sys.exit(0)
     else:
         LOGGER.error(
             "Error occurred in updating IP. Response from server:{}".format(


### PR DESCRIPTION
Hi,

I don't really think that finding the same IP is an 'error'
Plus, for those like me who wants to run this script in a k8s cronjob to ensure that it is refreshed oftenly, exiting with a code not 0 means pod status error.
That's why I propose its removal.

What do you think ?